### PR TITLE
Allow custom base URL for OpenAiService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 target
 pom.xml
 CraftGPT.iml

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.theokanning.openai-gpt3-java</groupId>
             <artifactId>service</artifactId>
-            <version>0.12.0</version>
+            <version>0.14.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -105,6 +105,11 @@
             <artifactId>adventure-platform-bukkit</artifactId>
             <version>4.3.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.zawn.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>2.10.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,11 @@ chatgpt:
   # NOTE: This is only stored locally and is not used for anything other than making requests.
   token: ""
 
+  # API base url.
+  # Change this if you wish to use alternative API endpoints (e.g. https://api.openai-proxy.com/).
+  # Make sure that it is compatible with OpenAI API calls.
+  base-url: https://api.openai.com/
+
   # ID of the model to use.
   # See https://platform.openai.com/docs/models/model-endpoint-compatibility
   # for details on which models work with the Chat API.


### PR DESCRIPTION
According to <https://github.com/TheoKanning/openai-java/issues/234>, it is possible to use a custom base URL (e.g. <https://api.openai-proxy.com/>) to replace OpenAI's official API (<https://api.openai.com/>). This can resolve certain issues like the one mentioned in #1.

P.S. there's a [pull request for openai-java](https://github.com/TheoKanning/openai-java/pull/343) that could simplify the implementation, but it's not merged yet.